### PR TITLE
Add workout management UI and flows

### DIFF
--- a/swim_app/forms.py
+++ b/swim_app/forms.py
@@ -23,8 +23,7 @@ class UploadForm(FlaskForm):
     submit = SubmitField("Extract workout")
 
 
-class ReviewForm(FlaskForm):
-    upload_id = HiddenField(validators=[DataRequired()])
+class WorkoutForm(FlaskForm):
     workout_date = StringField("Workout date", validators=[DataRequired()])
     start_time = StringField("Start time", validators=[DataRequired()])
     end_time = StringField("End time")
@@ -37,7 +36,41 @@ class ReviewForm(FlaskForm):
     backstroke_distance = StringField("Backstroke distance")
     butterfly_distance = StringField("Butterfly distance")
     allow_stroke_mismatch = BooleanField("Allow stroke total mismatch")
+
+
+class ReviewForm(WorkoutForm):
+    upload_id = HiddenField(validators=[DataRequired()])
     submit = SubmitField("Save workout")
+
+
+class EditWorkoutForm(WorkoutForm):
+    submit = SubmitField("Save changes")
+
+
+class WorkoutFilterForm(FlaskForm):
+    days = SelectField(
+        "Last x days",
+        choices=[
+            ("7", "Last 7 days"),
+            ("30", "Last 30 days"),
+            ("90", "Last 90 days"),
+            ("365", "Last 365 days"),
+            ("all", "All time"),
+        ],
+        default="30",
+        validators=[DataRequired()],
+    )
+    limit = SelectField(
+        "Results",
+        choices=[("1", "1"), ("10", "10"), ("25", "25"), ("50", "50"), ("100", "100")],
+        default="10",
+        validators=[DataRequired()],
+    )
+    submit = SubmitField("Apply filters")
+
+
+class DeleteWorkoutForm(FlaskForm):
+    submit = SubmitField("Delete workout")
 
 
 class MappingForm(FlaskForm):

--- a/swim_app/routes.py
+++ b/swim_app/routes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from uuid import uuid4
 import os
@@ -17,10 +17,19 @@ from flask import (
     url_for,
 )
 from flask_login import current_user, login_required, login_user, logout_user
+from sqlalchemy import func
 from werkzeug.utils import secure_filename
 
 from .extensions import db
-from .forms import LoginForm, MappingForm, ReviewForm, UploadForm
+from .forms import (
+    DeleteWorkoutForm,
+    EditWorkoutForm,
+    LoginForm,
+    MappingForm,
+    ReviewForm,
+    UploadForm,
+    WorkoutFilterForm,
+)
 from .models import StrokeMapping, UploadSession, User, Workout
 from .parser import build_start_datetime, parse_workout
 
@@ -100,66 +109,28 @@ def review(upload_id: int):
 
     duplicate_matches = _find_duplicate_workouts(payload)
     stroke_total = _sum_stroke_fields(payload)
-    stroke_mismatch = (
-        payload.get("total_distance_yards", 0) > 0
-        and stroke_total != payload.get("total_distance_yards", 0)
-    )
+    stroke_mismatch = _has_stroke_mismatch(payload, stroke_total)
 
     if review_form.validate_on_submit():
-        total_distance_yards = int(review_form.total_distance_yards.data)
-        freestyle_distance = _optional_int(review_form.freestyle_distance.data) or 0
-        breaststroke_distance = _optional_int(review_form.breaststroke_distance.data) or 0
-        backstroke_distance = _optional_int(review_form.backstroke_distance.data) or 0
-        butterfly_distance = _optional_int(review_form.butterfly_distance.data) or 0
-        reviewed_stroke_total = (
-            freestyle_distance
-            + breaststroke_distance
-            + backstroke_distance
-            + butterfly_distance
-        )
-        reviewed_payload = {
-            "workout_date": review_form.workout_date.data,
-            "start_time": review_form.start_time.data,
-            "location": review_form.location.data.strip(),
-            "total_distance_yards": total_distance_yards,
-            "duration": int(review_form.duration.data),
-        }
-        duplicate_matches = _find_duplicate_workouts(reviewed_payload)
-        stroke_total = reviewed_stroke_total
-        stroke_mismatch = (
-            total_distance_yards > 0 and reviewed_stroke_total != total_distance_yards
-        )
+        workout_data = _extract_workout_form_data(review_form)
+        duplicate_matches = _find_duplicate_workouts(workout_data)
+        stroke_total = workout_data["stroke_total"]
+        stroke_mismatch = workout_data["stroke_mismatch"]
 
         if stroke_mismatch and not review_form.allow_stroke_mismatch.data:
-            flash(
-                "Stroke total does not equal total distance. Correct the values or check the override box.",
-                "error",
-            )
-            return render_template(
-                "review.html",
-                form=review_form,
-                upload_session=upload_session,
-                mapping_forms=mapping_forms,
-                unknown_strokes=payload.get("unknown_strokes", []),
-                raw_strokes=payload.get("raw_strokes", []),
-                duplicate_matches=duplicate_matches,
-                stroke_total=stroke_total,
-                stroke_mismatch=stroke_mismatch,
+            return _render_review_template(
+                review_form,
+                upload_session,
+                payload,
+                mapping_forms,
+                duplicate_matches,
+                stroke_total,
+                stroke_mismatch,
+                flash_mismatch=True,
             )
 
-        workout = Workout(
-            start_date_time=build_start_datetime(
-                review_form.workout_date.data, review_form.start_time.data
-            ),
-            duration=int(review_form.duration.data),
-            total_distance_yards=total_distance_yards,
-            location=review_form.location.data.strip(),
-            comments=review_form.comments.data.strip() or None,
-            freestyle_distance=freestyle_distance or None,
-            breaststroke_distance=breaststroke_distance or None,
-            backstroke_distance=backstroke_distance or None,
-            butterfly_distance=butterfly_distance or None,
-        )
+        workout = Workout()
+        _apply_workout_data(workout, workout_data)
         db.session.add(workout)
         db.session.delete(upload_session)
         db.session.commit()
@@ -167,17 +138,96 @@ def review(upload_id: int):
         flash("Workout saved.", "success")
         return redirect(url_for("main.upload"))
 
+    return _render_review_template(
+        review_form,
+        upload_session,
+        payload,
+        mapping_forms,
+        duplicate_matches,
+        stroke_total,
+        stroke_mismatch,
+    )
+
+
+@bp.route("/workouts", methods=["GET", "POST"])
+@login_required
+def manage_workouts():
+    form = WorkoutFilterForm(formdata=request.args if request.method == "GET" else None)
+    if request.method == "POST" and form.validate_on_submit():
+        query_params = _workout_filter_query_params(form)
+        return redirect(url_for("main.manage_workouts", **query_params))
+
+    workouts = _query_workouts(form)
     return render_template(
-        "review.html",
-        form=review_form,
-        upload_session=upload_session,
-        mapping_forms=mapping_forms,
-        unknown_strokes=payload.get("unknown_strokes", []),
-        raw_strokes=payload.get("raw_strokes", []),
+        "manage_workouts.html",
+        form=form,
+        workouts=workouts,
+        active_filters=_workout_filter_query_params(form),
+    )
+
+
+@bp.route("/workouts/<int:workout_id>/edit", methods=["GET", "POST"])
+@login_required
+def edit_workout(workout_id: int):
+    workout = db.session.get(Workout, workout_id)
+    if not workout:
+        abort(404)
+
+    form = EditWorkoutForm(data=_workout_to_form_data(workout))
+    duplicate_matches = _find_duplicate_workouts(_workout_to_duplicate_payload(workout), workout.id)
+    stroke_total = _sum_stroke_fields(_workout_to_form_data(workout))
+    stroke_mismatch = _has_stroke_mismatch(_workout_to_form_data(workout), stroke_total)
+
+    if form.validate_on_submit():
+        workout_data = _extract_workout_form_data(form)
+        duplicate_matches = _find_duplicate_workouts(workout_data, workout.id)
+        stroke_total = workout_data["stroke_total"]
+        stroke_mismatch = workout_data["stroke_mismatch"]
+
+        if stroke_mismatch and not form.allow_stroke_mismatch.data:
+            flash(
+                "Stroke total does not equal total distance. Correct the values or check the override box.",
+                "error",
+            )
+            return render_template(
+                "edit_workout.html",
+                form=form,
+                workout=workout,
+                duplicate_matches=duplicate_matches,
+                stroke_total=stroke_total,
+                stroke_mismatch=stroke_mismatch,
+            )
+
+        _apply_workout_data(workout, workout_data)
+        db.session.commit()
+        flash("Workout updated.", "success")
+        return redirect(url_for("main.manage_workouts"))
+
+    return render_template(
+        "edit_workout.html",
+        form=form,
+        workout=workout,
         duplicate_matches=duplicate_matches,
         stroke_total=stroke_total,
         stroke_mismatch=stroke_mismatch,
     )
+
+
+@bp.route("/workouts/<int:workout_id>/delete", methods=["GET", "POST"])
+@login_required
+def delete_workout(workout_id: int):
+    workout = db.session.get(Workout, workout_id)
+    if not workout:
+        abort(404)
+
+    form = DeleteWorkoutForm()
+    if form.validate_on_submit():
+        db.session.delete(workout)
+        db.session.commit()
+        flash("Workout deleted.", "success")
+        return redirect(url_for("main.manage_workouts"))
+
+    return render_template("delete_workout.html", form=form, workout=workout)
 
 
 @bp.route("/stroke-mappings", methods=["POST"])
@@ -207,6 +257,121 @@ def uploaded_file(filename: str):
     return send_from_directory(Path(bp.root_path).parent / "uploads", filename)
 
 
+def _render_review_template(
+    form: ReviewForm,
+    upload_session: UploadSession,
+    payload: dict,
+    mapping_forms: list[MappingForm],
+    duplicate_matches: list[Workout],
+    stroke_total: int,
+    stroke_mismatch: bool,
+    flash_mismatch: bool = False,
+):
+    if stroke_mismatch and flash_mismatch:
+        flash(
+            "Stroke total does not equal total distance. Correct the values or check the override box.",
+            "error",
+        )
+    return render_template(
+        "review.html",
+        form=form,
+        upload_session=upload_session,
+        mapping_forms=mapping_forms,
+        unknown_strokes=payload.get("unknown_strokes", []),
+        raw_strokes=payload.get("raw_strokes", []),
+        duplicate_matches=duplicate_matches,
+        stroke_total=stroke_total,
+        stroke_mismatch=stroke_mismatch,
+    )
+
+
+def _extract_workout_form_data(form) -> dict:
+    total_distance_yards = int(form.total_distance_yards.data)
+    freestyle_distance = _optional_int(form.freestyle_distance.data) or 0
+    breaststroke_distance = _optional_int(form.breaststroke_distance.data) or 0
+    backstroke_distance = _optional_int(form.backstroke_distance.data) or 0
+    butterfly_distance = _optional_int(form.butterfly_distance.data) or 0
+    stroke_total = (
+        freestyle_distance
+        + breaststroke_distance
+        + backstroke_distance
+        + butterfly_distance
+    )
+    payload = {
+        "workout_date": form.workout_date.data,
+        "start_time": form.start_time.data,
+        "end_time": form.end_time.data,
+        "location": form.location.data.strip(),
+        "total_distance_yards": total_distance_yards,
+        "duration": int(form.duration.data),
+        "comments": form.comments.data.strip() or None,
+        "freestyle_distance": freestyle_distance,
+        "breaststroke_distance": breaststroke_distance,
+        "backstroke_distance": backstroke_distance,
+        "butterfly_distance": butterfly_distance,
+        "stroke_total": stroke_total,
+        "stroke_mismatch": total_distance_yards > 0 and stroke_total != total_distance_yards,
+    }
+    return payload
+
+
+def _apply_workout_data(workout: Workout, payload: dict) -> None:
+    workout.start_date_time = build_start_datetime(
+        payload["workout_date"], payload["start_time"]
+    )
+    workout.duration = payload["duration"]
+    workout.total_distance_yards = payload["total_distance_yards"]
+    workout.location = payload["location"]
+    workout.comments = payload["comments"]
+    workout.freestyle_distance = payload["freestyle_distance"] or None
+    workout.breaststroke_distance = payload["breaststroke_distance"] or None
+    workout.backstroke_distance = payload["backstroke_distance"] or None
+    workout.butterfly_distance = payload["butterfly_distance"] or None
+
+
+def _workout_to_form_data(workout: Workout) -> dict:
+    return {
+        "workout_date": workout.start_date_time.strftime("%Y-%m-%d"),
+        "start_time": workout.start_date_time.strftime("%H:%M"),
+        "end_time": _format_end_time(workout.start_date_time, workout.duration),
+        "duration": str(workout.duration),
+        "total_distance_yards": str(workout.total_distance_yards),
+        "location": workout.location,
+        "comments": workout.comments or "",
+        "freestyle_distance": _stringify_optional_int(workout.freestyle_distance),
+        "breaststroke_distance": _stringify_optional_int(workout.breaststroke_distance),
+        "backstroke_distance": _stringify_optional_int(workout.backstroke_distance),
+        "butterfly_distance": _stringify_optional_int(workout.butterfly_distance),
+    }
+
+
+def _workout_to_duplicate_payload(workout: Workout) -> dict:
+    return {
+        "workout_date": workout.start_date_time.strftime("%Y-%m-%d"),
+        "start_time": workout.start_date_time.strftime("%H:%M"),
+        "location": workout.location,
+        "total_distance_yards": workout.total_distance_yards,
+        "duration": workout.duration,
+    }
+
+
+def _query_workouts(form: WorkoutFilterForm) -> list[Workout]:
+    query = Workout.query
+    days = _parse_days(form.days.data)
+    if days is not None:
+        cutoff = datetime.combine(date.today() - timedelta(days=days - 1), datetime.min.time())
+        query = query.filter(Workout.start_date_time >= cutoff)
+    limit = _parse_limit(form.limit.data)
+    return query.order_by(Workout.start_date_time.desc()).limit(limit).all()
+
+
+def _workout_filter_query_params(form: WorkoutFilterForm) -> dict:
+    return {
+        "days": form.days.data if _parse_days(form.days.data) is None else str(_parse_days(form.days.data)),
+        "limit": str(_parse_limit(form.limit.data)),
+    }
+
+
 def _optional_int(value: str | None) -> int | None:
     if value is None:
         return None
@@ -216,7 +381,7 @@ def _optional_int(value: str | None) -> int | None:
     return int(stripped)
 
 
-def _find_duplicate_workouts(payload: dict) -> list[Workout]:
+def _find_duplicate_workouts(payload: dict, exclude_workout_id: int | None = None) -> list[Workout]:
     workout_date = payload.get("workout_date")
     start_time = payload.get("start_time")
     location = payload.get("location")
@@ -227,16 +392,15 @@ def _find_duplicate_workouts(payload: dict) -> list[Workout]:
         return []
 
     start_date_time = build_start_datetime(workout_date, start_time)
-    return (
-        Workout.query.filter_by(
-            start_date_time=start_date_time,
-            location=location,
-            total_distance_yards=total_distance_yards,
-            duration=duration,
-        )
-        .order_by(Workout.id.desc())
-        .all()
+    query = Workout.query.filter_by(
+        start_date_time=start_date_time,
+        location=location,
+        total_distance_yards=total_distance_yards,
+        duration=duration,
     )
+    if exclude_workout_id is not None:
+        query = query.filter(Workout.id != exclude_workout_id)
+    return query.order_by(Workout.id.desc()).all()
 
 
 def _sum_stroke_fields(payload: dict) -> int:
@@ -249,6 +413,42 @@ def _sum_stroke_fields(payload: dict) -> int:
             "butterfly_distance",
         ]
     )
+
+
+def _has_stroke_mismatch(payload: dict, stroke_total: int) -> bool:
+    total_distance_yards = int(payload.get("total_distance_yards") or 0)
+    return total_distance_yards > 0 and stroke_total != total_distance_yards
+
+
+def _parse_limit(raw_limit: str | None) -> int:
+    allowed_limits = {1, 10, 25, 50, 100}
+    try:
+        limit = int(raw_limit or 10)
+    except ValueError:
+        return 10
+    return limit if limit in allowed_limits else 10
+
+
+def _parse_days(raw_days: str | None) -> int | None:
+    if raw_days == "all":
+        return None
+    allowed_days = {7, 30, 90, 365}
+    try:
+        days = int(raw_days or 30)
+    except ValueError:
+        return 30
+    return days if days in allowed_days else 30
+
+
+def _stringify_optional_int(value: int | None) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _format_end_time(start_date_time: datetime, duration_minutes: int) -> str:
+    end_time = start_date_time + timedelta(minutes=duration_minutes)
+    return end_time.strftime("%H:%M")
 
 
 def _delete_uploaded_file(filename: str) -> None:

--- a/swim_app/static/styles.css
+++ b/swim_app/static/styles.css
@@ -91,6 +91,33 @@ body {
   gap: 0.85rem;
 }
 
+.header-tabs {
+  display: inline-flex;
+  gap: 0.45rem;
+  padding: 0.3rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.header-tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 0.95rem;
+  border-radius: 999px;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.header-tab.is-active {
+  background: var(--accent-50);
+  color: var(--accent-dark);
+}
+
 .dashboard-link {
   color: var(--accent-dark);
   text-decoration: none;
@@ -137,6 +164,13 @@ body {
   color: #334155;
   white-space: normal;
   overflow-wrap: anywhere;
+}
+
+.panel-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
 }
 
 .stack {
@@ -193,6 +227,18 @@ textarea:focus {
   border: 1px solid var(--accent-100);
 }
 
+.danger-button {
+  background: #fff1f2;
+  color: var(--error);
+  border: 1px solid #fecdd3;
+}
+
+.primary-button.danger-button {
+  background: linear-gradient(135deg, #e11d48 0%, #be123c 100%);
+  color: white;
+  border: 0;
+}
+
 .review-grid {
   display: grid;
   grid-template-columns: 1.4fr 1fr;
@@ -203,6 +249,10 @@ textarea:focus {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.9rem;
+}
+
+.compact-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .preview-image {
@@ -266,6 +316,33 @@ textarea:focus {
   margin-bottom: 0.8rem;
 }
 
+.workout-list {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.workout-row {
+  display: grid;
+  gap: 0.65rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, rgba(239, 246, 255, 0.45) 0%, rgba(255, 255, 255, 0.95) 100%);
+}
+
+.workout-summary,
+.workout-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 1rem;
+}
+
+.workout-meta {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
 .form-actions {
   display: flex;
   gap: 0.85rem;
@@ -281,7 +358,8 @@ textarea:focus {
 
 @media (max-width: 820px) {
   .review-grid,
-  .field-grid {
+  .field-grid,
+  .compact-grid {
     grid-template-columns: 1fr;
   }
 
@@ -306,10 +384,15 @@ textarea:focus {
   }
 
   .icon-link,
+  .header-tabs,
   .ghost-button,
   .link-button,
   .form-actions .primary-button {
     width: 100%;
+  }
+
+  .header-tabs {
+    display: grid;
   }
 
   .form-actions {

--- a/swim_app/templates/_workout_form_fields.html
+++ b/swim_app/templates/_workout_form_fields.html
@@ -1,0 +1,20 @@
+<div class="field-grid">
+  <label><span>Workout date</span>{{ form.workout_date() }}</label>
+  <label><span>Start time</span>{{ form.start_time() }}</label>
+  <label><span>End time</span>{{ form.end_time(readonly=true) }}</label>
+  <label><span>Duration (minutes)</span>{{ form.duration() }}</label>
+  <label><span>Total distance yards</span>{{ form.total_distance_yards() }}</label>
+  <label><span>Location</span>{{ form.location() }}</label>
+  <label><span>Freestyle yards</span>{{ form.freestyle_distance() }}</label>
+  <label><span>Breaststroke yards</span>{{ form.breaststroke_distance() }}</label>
+  <label><span>Backstroke yards</span>{{ form.backstroke_distance() }}</label>
+  <label><span>Butterfly yards</span>{{ form.butterfly_distance() }}</label>
+</div>
+<label>
+  <span>Comments</span>
+  {{ form.comments(rows=4) }}
+</label>
+<label class="checkbox-row">
+  {{ form.allow_stroke_mismatch() }}
+  <span>Allow save when stroke total does not match total distance</span>
+</label>

--- a/swim_app/templates/base.html
+++ b/swim_app/templates/base.html
@@ -13,9 +13,15 @@
         <div class="dashboard-header-inner">
           <div>
             <h1 class="dashboard-title">Swim Workout Writer</h1>
-            <p class="dashboard-subtitle">Upload, review, and save Apple Workouts swim sessions.</p>
+            <p class="dashboard-subtitle">Upload, review, edit, and delete Apple Workouts swim sessions.</p>
           </div>
           <div class="header-actions">
+            {% if current_user.is_authenticated %}
+              <nav class="header-tabs" aria-label="Primary">
+                <a class="header-tab {{ 'is-active' if request.endpoint in ['main.upload', 'main.review'] else '' }}" href="{{ url_for('main.upload') }}">Upload</a>
+                <a class="header-tab {{ 'is-active' if request.endpoint in ['main.manage_workouts', 'main.edit_workout', 'main.delete_workout'] else '' }}" href="{{ url_for('main.manage_workouts') }}">Manage Workouts</a>
+              </nav>
+            {% endif %}
             <a class="dashboard-link icon-link" href="https://analytics.johnthompson.io/dashboard/swim_tracking" target="_blank" rel="noreferrer">
               Swim Dashboard
             </a>

--- a/swim_app/templates/delete_workout.html
+++ b/swim_app/templates/delete_workout.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <section class="panel narrow stack">
+    <h2>Delete Workout</h2>
+    <p class="panel-copy">This permanently removes the saved workout record.</p>
+    <ul class="plain-list">
+      <li>{{ workout.start_date_time.strftime('%Y-%m-%d %H:%M') }}</li>
+      <li>{{ workout.location }}</li>
+      <li>{{ workout.total_distance_yards }} yd</li>
+      <li>{{ workout.duration }} min</li>
+    </ul>
+    {% if workout.comments %}
+      <p class="muted-note">{{ workout.comments }}</p>
+    {% endif %}
+    <form method="post" class="form-actions">
+      {{ form.hidden_tag() }}
+      <a class="ghost-button link-button" href="{{ url_for('main.manage_workouts') }}">Cancel</a>
+      {{ form.submit(class_="primary-button danger-button") }}
+    </form>
+  </section>
+{% endblock %}

--- a/swim_app/templates/edit_workout.html
+++ b/swim_app/templates/edit_workout.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <section class="review-grid">
+    <article class="panel">
+      <h2>Edit Workout</h2>
+      {% if duplicate_matches %}
+        <div class="inline-warning">
+          Possible duplicate: {{ duplicate_matches|length }} existing workout{{ '' if duplicate_matches|length == 1 else 's' }} match this date, time, location, distance, and duration.
+        </div>
+      {% endif %}
+      {% if stroke_mismatch %}
+        <div class="inline-warning">
+          Stroke total is {{ stroke_total }} yd, but total distance is {{ form.total_distance_yards.data }} yd.
+        </div>
+      {% endif %}
+      <form method="post" class="stack">
+        {{ form.hidden_tag() }}
+        {% include "_workout_form_fields.html" %}
+        <div class="form-actions">
+          <a class="ghost-button link-button" href="{{ url_for('main.manage_workouts') }}">Back to manage</a>
+          {{ form.submit(class_="primary-button") }}
+        </div>
+      </form>
+    </article>
+
+    <aside class="stack">
+      <section class="panel">
+        <h3>Current Record</h3>
+        <ul class="plain-list">
+          <li>{{ workout.start_date_time.strftime('%Y-%m-%d %H:%M') }}</li>
+          <li>{{ workout.location }}</li>
+          <li>{{ workout.total_distance_yards }} yd</li>
+          <li>{{ workout.duration }} min</li>
+        </ul>
+      </section>
+
+      {% if duplicate_matches %}
+        <section class="panel">
+          <h3>Possible Duplicates</h3>
+          <ul class="plain-list">
+            {% for match in duplicate_matches %}
+              <li>{{ match.start_date_time.strftime('%Y-%m-%d %H:%M') }} | {{ match.location }} | {{ match.total_distance_yards }} yd | {{ match.duration }} min</li>
+            {% endfor %}
+          </ul>
+        </section>
+      {% endif %}
+    </aside>
+  </section>
+{% endblock %}

--- a/swim_app/templates/manage_workouts.html
+++ b/swim_app/templates/manage_workouts.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <section class="stack">
+    <article class="panel hero-panel">
+      <div class="panel-heading">
+        <div>
+          <h2>Manage Workouts</h2>
+          <p class="panel-copy">Browse recent swim workouts by time range, then edit or delete a saved record without entering the upload flow.</p>
+        </div>
+      </div>
+      <form method="post" class="stack">
+        {{ form.hidden_tag() }}
+        <div class="field-grid compact-grid">
+          <label>{{ form.days(aria_label="Last x days") }}</label>
+          <label><span>Results</span>{{ form.limit() }}</label>
+        </div>
+        <div class="form-actions">
+          {{ form.submit(class_="primary-button") }}
+          <a class="ghost-button link-button" href="{{ url_for('main.manage_workouts') }}">Reset</a>
+        </div>
+      </form>
+    </article>
+
+    <section class="panel">
+      <div class="panel-heading">
+        <div>
+          <h3>Saved Workouts</h3>
+          <p class="panel-copy">Newest sessions first.</p>
+        </div>
+      </div>
+      {% if workouts %}
+        <div class="workout-list">
+          {% for workout in workouts %}
+            <article class="workout-row">
+              <div class="workout-summary">
+                <strong>{{ workout.start_date_time.strftime('%Y-%m-%d %H:%M') }}</strong>
+                <span>{{ workout.location }}</span>
+                <span>{{ workout.total_distance_yards }} yd</span>
+                <span>{{ workout.duration }} min</span>
+              </div>
+              <div class="workout-meta">
+                <span>Free {{ workout.freestyle_distance or 0 }} yd</span>
+                <span>Breast {{ workout.breaststroke_distance or 0 }} yd</span>
+                <span>Back {{ workout.backstroke_distance or 0 }} yd</span>
+                <span>Fly {{ workout.butterfly_distance or 0 }} yd</span>
+              </div>
+              {% if workout.comments %}
+                <p class="muted-note">{{ workout.comments }}</p>
+              {% endif %}
+              <div class="form-actions">
+                <a class="ghost-button link-button" href="{{ url_for('main.edit_workout', workout_id=workout.id) }}">Edit</a>
+                <a class="ghost-button link-button danger-button" href="{{ url_for('main.delete_workout', workout_id=workout.id) }}">Delete</a>
+              </div>
+            </article>
+          {% endfor %}
+        </div>
+      {% else %}
+        <p class="muted-note">No workouts matched the current filters.</p>
+      {% endif %}
+    </section>
+  </section>
+{% endblock %}

--- a/swim_app/templates/review.html
+++ b/swim_app/templates/review.html
@@ -16,26 +16,7 @@
       {% endif %}
       <form method="post" class="stack">
         {{ form.hidden_tag() }}
-        <div class="field-grid">
-          <label><span>Workout date</span>{{ form.workout_date() }}</label>
-          <label><span>Start time</span>{{ form.start_time() }}</label>
-          <label><span>End time</span>{{ form.end_time() }}</label>
-          <label><span>Duration (minutes)</span>{{ form.duration() }}</label>
-          <label><span>Total distance yards</span>{{ form.total_distance_yards() }}</label>
-          <label><span>Location</span>{{ form.location() }}</label>
-          <label><span>Freestyle yards</span>{{ form.freestyle_distance() }}</label>
-          <label><span>Breaststroke yards</span>{{ form.breaststroke_distance() }}</label>
-          <label><span>Backstroke yards</span>{{ form.backstroke_distance() }}</label>
-          <label><span>Butterfly yards</span>{{ form.butterfly_distance() }}</label>
-        </div>
-        <label>
-          <span>Comments</span>
-          {{ form.comments(rows=4) }}
-        </label>
-        <label class="checkbox-row">
-          {{ form.allow_stroke_mismatch() }}
-          <span>Allow save when stroke total does not match total distance</span>
-        </label>
+        {% include "_workout_form_fields.html" %}
         <div class="form-actions">
           <a class="ghost-button link-button" href="{{ url_for('main.upload') }}">Back to upload</a>
           {{ form.submit(class_="primary-button") }}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -31,6 +31,34 @@ def login(client):
         data={"username": "tester", "password": "secret-pass"},
         follow_redirects=True,
     )
+
+
+def create_workout(
+    *,
+    start_date_time=datetime(2026, 3, 24, 16, 45),
+    duration=30,
+    total_distance_yards=736,
+    location="Minnetonka",
+    comments=None,
+    freestyle_distance=598,
+    breaststroke_distance=138,
+    backstroke_distance=None,
+    butterfly_distance=None,
+):
+    workout = Workout(
+        start_date_time=start_date_time,
+        duration=duration,
+        total_distance_yards=total_distance_yards,
+        location=location,
+        comments=comments,
+        freestyle_distance=freestyle_distance,
+        breaststroke_distance=breaststroke_distance,
+        backstroke_distance=backstroke_distance,
+        butterfly_distance=butterfly_distance,
+    )
+    db.session.add(workout)
+    db.session.commit()
+    return workout
 
 
 def test_parse_sample_workout(app):
@@ -71,20 +99,7 @@ def test_parse_total_distance_can_fall_back_to_stroke_sum(app):
 
 def test_find_duplicate_workouts_matches_existing_row(app):
     with app.app_context():
-        db.session.add(
-            Workout(
-                start_date_time=datetime(2026, 3, 24, 16, 45),
-                duration=30,
-                total_distance_yards=736,
-                location="Minnetonka",
-                comments=None,
-                freestyle_distance=598,
-                breaststroke_distance=138,
-                backstroke_distance=None,
-                butterfly_distance=None,
-            )
-        )
-        db.session.commit()
+        create_workout()
 
         matches = _find_duplicate_workouts(
             {
@@ -169,19 +184,7 @@ def test_review_shows_duplicate_warning(app, client):
     login(client)
 
     with app.app_context():
-        db.session.add(
-            Workout(
-                start_date_time=datetime(2026, 3, 24, 16, 45),
-                duration=30,
-                total_distance_yards=736,
-                location="Minnetonka",
-                comments=None,
-                freestyle_distance=598,
-                breaststroke_distance=138,
-                backstroke_distance=None,
-                butterfly_distance=None,
-            )
-        )
+        create_workout()
         session = UploadSession(
             image_filename="fake.png",
             extracted_payload={
@@ -261,3 +264,188 @@ def test_review_save_deletes_uploaded_file_after_success(app, client):
 
     assert response.status_code == 200
     assert not upload_path.exists()
+
+
+def test_manage_workouts_requires_login(client):
+    response = client.get("/workouts")
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_manage_workouts_shows_recent_workouts_by_default(app, client):
+    login(client)
+    today = date.today()
+
+    with app.app_context():
+        for index in range(12):
+            create_workout(
+                start_date_time=datetime.combine(today - timedelta(days=index), datetime.min.time()).replace(hour=7, minute=15),
+                location=f"Pool {index}",
+                freestyle_distance=736,
+                breaststroke_distance=None,
+            )
+
+    response = client.get("/workouts")
+
+    assert b"Manage Workouts" in response.data
+    tenth_day = (today - timedelta(days=9)).strftime("%Y-%m-%d 07:15").encode()
+    eleventh_day = (today - timedelta(days=10)).strftime("%Y-%m-%d 07:15").encode()
+    newest_day = today.strftime("%Y-%m-%d 07:15").encode()
+    assert newest_day in response.data
+    assert tenth_day in response.data
+    assert eleventh_day not in response.data
+
+
+def test_manage_workouts_filters_by_last_x_days_and_limit(app, client):
+    login(client)
+    today = date.today()
+
+    with app.app_context():
+        create_workout(
+            start_date_time=datetime.combine(today - timedelta(days=1), datetime.min.time()).replace(hour=16, minute=45),
+            location="Minnetonka",
+        )
+        create_workout(
+            start_date_time=datetime.combine(today - timedelta(days=3), datetime.min.time()).replace(hour=18, minute=0),
+            location="St. Louis Park",
+            freestyle_distance=736,
+            breaststroke_distance=None,
+        )
+        create_workout(
+            start_date_time=datetime.combine(today - timedelta(days=12), datetime.min.time()).replace(hour=7, minute=15),
+            location="YWCA",
+            freestyle_distance=736,
+            breaststroke_distance=None,
+        )
+
+    response = client.get("/workouts?days=7&limit=1")
+
+    newest_in_window = (today - timedelta(days=1)).strftime("%Y-%m-%d 16:45").encode()
+    older_in_window = (today - timedelta(days=3)).strftime("%Y-%m-%d 18:00").encode()
+    outside_window = (today - timedelta(days=12)).strftime("%Y-%m-%d 07:15").encode()
+    assert newest_in_window in response.data
+    assert older_in_window not in response.data
+    assert outside_window not in response.data
+    assert b"YWCA" not in response.data
+
+
+def test_edit_workout_updates_existing_record(app, client):
+    login(client)
+
+    with app.app_context():
+        workout = create_workout(comments="Before")
+        workout_id = workout.id
+
+    response = client.post(
+        f"/workouts/{workout_id}/edit",
+        data={
+            "workout_date": "2026-03-24",
+            "start_time": "17:00",
+            "end_time": "17:30",
+            "duration": "30",
+            "total_distance_yards": "800",
+            "location": "Minnetonka Community Center",
+            "comments": "After",
+            "freestyle_distance": "600",
+            "breaststroke_distance": "100",
+            "backstroke_distance": "100",
+            "butterfly_distance": "0",
+        },
+        follow_redirects=True,
+    )
+
+    assert b"Workout updated." in response.data
+    with app.app_context():
+        workout = db.session.get(Workout, workout_id)
+        assert workout.start_date_time == datetime(2026, 3, 24, 17, 0)
+        assert workout.location == "Minnetonka Community Center"
+        assert workout.total_distance_yards == 800
+        assert workout.comments == "After"
+        assert workout.backstroke_distance == 100
+
+
+def test_edit_workout_blocks_mismatched_strokes_without_override(app, client):
+    login(client)
+
+    with app.app_context():
+        workout = create_workout()
+        workout_id = workout.id
+
+    response = client.post(
+        f"/workouts/{workout_id}/edit",
+        data={
+            "workout_date": "2026-03-24",
+            "start_time": "16:45",
+            "end_time": "17:15",
+            "duration": "30",
+            "total_distance_yards": "736",
+            "location": "Minnetonka",
+            "comments": "",
+            "freestyle_distance": "500",
+            "breaststroke_distance": "100",
+            "backstroke_distance": "0",
+            "butterfly_distance": "0",
+        },
+        follow_redirects=True,
+    )
+
+    assert b"Stroke total does not equal total distance" in response.data
+    with app.app_context():
+        workout = db.session.get(Workout, workout_id)
+        assert workout.total_distance_yards == 736
+        assert workout.freestyle_distance == 598
+
+
+def test_edit_workout_duplicate_warning_excludes_self_and_detects_other_rows(app, client):
+    login(client)
+
+    with app.app_context():
+        primary = create_workout()
+        primary_id = primary.id
+
+    self_response = client.get(f"/workouts/{primary_id}/edit")
+    assert b"Possible duplicate" not in self_response.data
+
+    with app.app_context():
+        create_workout(
+            start_date_time=datetime(2026, 3, 24, 16, 45),
+            location="Minnetonka",
+            freestyle_distance=736,
+            breaststroke_distance=None,
+        )
+
+    duplicate_response = client.get(f"/workouts/{primary_id}/edit")
+    assert b"Possible duplicate" in duplicate_response.data
+
+
+def test_delete_workout_confirmation_and_submit(app, client):
+    login(client)
+
+    with app.app_context():
+        workout = create_workout(comments="Delete me")
+        workout_id = workout.id
+
+    confirm_response = client.get(f"/workouts/{workout_id}/delete")
+    assert b"Delete Workout" in confirm_response.data
+    assert b"Delete me" in confirm_response.data
+
+    delete_response = client.post(
+        f"/workouts/{workout_id}/delete",
+        data={},
+        follow_redirects=True,
+    )
+
+    assert b"Workout deleted." in delete_response.data
+    with app.app_context():
+        assert db.session.get(Workout, workout_id) is None
+
+
+def test_manage_and_delete_missing_workout_returns_404(app, client):
+    login(client)
+
+    edit_response = client.get("/workouts/999/edit")
+    delete_response = client.get("/workouts/999/delete")
+
+    assert edit_response.status_code == 404
+    assert delete_response.status_code == 404


### PR DESCRIPTION
## Summary

  Adds a new authenticated workout management area separate from the upload/review flow.

  This PR introduces:
  - a new `Manage Workouts` tab in the header
  - a management page for browsing recent workouts
  - full edit support for existing workout records
  - dedicated delete confirmation for existing workout records
  - shared workout form/validation logic between create and edit flows

  ## What Changed

  ### Workout Management
  - Added a new `/workouts` page for managing saved workouts
  - Shows the most recent 10 workouts by default
  - Added filter controls for:
    - `Last x days`
    - result count
  - Keeps the existing styling and layout patterns used elsewhere in the app

  ### Edit Flow
  - Added a dedicated edit page for an existing workout
  - Supports editing the full workout record:
    - date
    - start time
    - duration
    - total distance
    - location
    - comments
    - stroke breakdown fields
  - Reuses the same stroke total mismatch validation as the upload review flow
  - Reuses duplicate detection logic, excluding the current record from self-matches

  ### Delete Flow
  - Added a dedicated delete confirmation page
  - Deletes the selected workout only after explicit confirmation

  ### Shared Form Logic
  - Refactored workout field handling so review/save and edit/update use shared logic
  - Added reusable template partials for workout form fields

  ### Navigation / UI
  - Added persistent header tabs for:
    - `Upload`
    - `Manage Workouts`
  - Updated app copy to reflect that workouts can now be uploaded, reviewed, edited, and deleted

  ## Testing

  Validated with:

  ```bash
  pytest -q

  Result:

  - 16 passed

  ## Notes

  - The management page filter was simplified during review:
      - removed location filtering
      - replaced exact date search with a Last x days dropdown
  - Current presets for Last x days are:
      - 7
      - 30
      - 90
      - 365
      - all time
